### PR TITLE
Update sealed_or_notdry, support moist containers

### DIFF
--- a/cultivate_coral.lua
+++ b/cultivate_coral.lua
@@ -52,9 +52,28 @@ local function notdry(pos)
 	end
 end
 
+local accessdirs = nodecore.dirs()
 local function sealed_or_notdry(nodename, pos)
-	if nodename == "nc_optics:shelf" then
-		return (not pos) or notdry({x = pos.x, y = pos.y + 1, z = pos.z})
+	local def = minetest.registered_nodes[nodename]
+	if def and def.groups then
+		if def.groups.moist and def.groups.moist > 0 then
+			return true
+		end
+		if def.groups.storebox_sealed and def.groups.storebox_sealed > 0 then
+			if not pos then return true end
+			for i = 1, #accessdirs do
+				local pt = {
+					type = "node",
+					above = vector.add(accessdirs[i], pos),
+					under = pos
+				}
+				if (not def.storebox_access) or def.storebox_access(pt, pos,
+					{name = nodename, param = 0, param2 = 0}) then
+					if not notdry(pt.above) then return end
+				end
+			end
+			return true
+		end
 	end
 	if not pos then return end
 	for _, d in pairs(alldirs) do


### PR DESCRIPTION
I've updated the `sealed_or_notdry` to match the [`nc_sponge` implementation](https://gitlab.com/sztest/nodecore/-/blob/master/mods/nc_sponge/cultivate.lua#L53-76) more directly. For example, the old implementation did not support `nc_optics:shelf_float`, since only the basic glass shelf was hardcoded.

In addition, I made it so containers that are considered `moist`, such as the `wc_pottery` ceramic waterpot, will count as "not dry". This allows said waterpots to hold living coral without them having to be placed underwater, which I believe does make sense.

![image](https://github.com/wintersknight94/NodeCore-SeaLife/assets/272586/c2ab9899-f34b-42fd-8b4f-8312c6aaba6e)

(I will suggest the same change to be made to NodeCore itself.)